### PR TITLE
Server List design update

### DIFF
--- a/src/routes/serverList/ServerList.css
+++ b/src/routes/serverList/ServerList.css
@@ -45,34 +45,6 @@
 .server {
   padding: 0;
 }
-/*
-.serverItem {
-  border: 3px solid #b5b2af;
-
-  -webkit-border-radius: 12px;
-
-
-  -moz-border-radius: 12px;
-
-  border-radius: 12px;
-
-  align-content: center;
-  align-items: center;
-  align-self: center;
-  box-sizing: border-box;
-  background-color: rgb(219, 219, 219);
-  padding-bottom: 6px;
-  margin: 10px;
-} */
-
-/*
-.serverList {
-  padding: 0;
-  margin: 0;
-  list-style-type: none;
-}
-*/
-
 
 .serverItem {
   border: 3px solid #b5b2af;
@@ -86,6 +58,7 @@
   margin-bottom: 15px;
   background-color: rgb(219, 219, 219);
 }
+
 .serverItem:nth-child(2n+1) {
   margin-left: 30px;
 }

--- a/src/routes/serverList/ServerList.css
+++ b/src/routes/serverList/ServerList.css
@@ -64,10 +64,33 @@
   margin: 10px;
 }
 
+/*
 .serverList {
   padding: 0;
   margin: 0;
   list-style-type: none;
+}
+*/
+
+
+.serveritem {
+  border: 3px solid #b5b2af;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  width: 100%;
+  padding: 15px;
+  background-color: rgb(219, 219, 219);
+}
+
+.serverguildicon {
+  width: 128px;
+  float: left;
+}
+
+.serverlabel {
+  width: 100%;
+  float: right;
+  font-family: sans-serif;
 }
 
 .serverTitle {

--- a/src/routes/serverList/ServerList.css
+++ b/src/routes/serverList/ServerList.css
@@ -17,6 +17,8 @@
 .container {
   margin: 0 auto;
   padding: 0 0 40px;
+  overflow: auto;
+  height: auto;
   max-width: var(--max-content-width);
 }
 
@@ -43,16 +45,15 @@
 .server {
   padding: 0;
 }
-
+/*
 .serverItem {
   border: 3px solid #b5b2af;
-  /* Safari 3-4, iOS 1-3.2, Android 1.6- */
+
   -webkit-border-radius: 12px;
 
-  /* Firefox 1-3.6 */
+
   -moz-border-radius: 12px;
 
-  /* Opera 10.5, IE 9, Safari 5, Chrome, Firefox 4, iOS 4, Android 2.1+ */
   border-radius: 12px;
 
   align-content: center;
@@ -62,7 +63,7 @@
   background-color: rgb(219, 219, 219);
   padding-bottom: 6px;
   margin: 10px;
-}
+} */
 
 /*
 .serverList {
@@ -73,25 +74,41 @@
 */
 
 
-.serveritem {
+.serverItem {
   border: 3px solid #b5b2af;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
-  width: 100%;
+  border-radius: 10px;
+  width: calc(50% - 30px - 6px - 15px);
+  float: left;
   padding: 15px;
+  height: 128px;
+  margin-bottom: 15px;
   background-color: rgb(219, 219, 219);
 }
+.serverItem:nth-child(2n+1) {
+  margin-left: 30px;
+}
 
-.serverguildicon {
+.serverGuildIcon {
   width: 128px;
   float: left;
 }
 
-.serverlabel {
-  width: 100%;
-  float: right;
-  font-family: sans-serif;
+.serverGuildIcon img {
+  border-radius: 64px;
 }
+
+.serverLabel {
+  width: calc(100% - 128px - 10px);
+  /* float: right; */
+  position: relative;
+  top: 50%;
+  left: 15px;
+  transform: translateY(-50%);
+}
+
+.serverLabel h3 { margin: 0; }
 
 .serverTitle {
   font-size: 1.125em;

--- a/src/routes/serverList/Serverlist.js
+++ b/src/routes/serverList/Serverlist.js
@@ -14,6 +14,10 @@ import s from './ServerList.css';
 
 const title = 'Server List';
 
+/*<li className={s.serverItem} key={guild.id}>
+ <img className={s.icon} src={guild.icon == null ? `https://discordapp.com/api/guilds/97069403178278912/icons/8d7a71e1507514e9ab4345056c8b5cc3.jpg` : `https://discordapp.com/api/guilds/${guild.id}/icons/${guild.icon}.jpg`}/>
+ <h3><a className={s.name} href={`/server/${guild.id}`}>{guild.name}</a></h3>
+ </li>*/
 const Grid = makeResponsive(measureItems(Grid), {
   height: "auto",
   maxWidth: 1920,
@@ -29,19 +33,22 @@ function ServerList({ user }, context) {
 
   const items = user.guilds.map(guild => {
     return (
-      <li className={s.serverItem} key={guild.id}>
-        <img className={s.icon} src={guild.icon == null ? `https://discordapp.com/api/guilds/97069403178278912/icons/8d7a71e1507514e9ab4345056c8b5cc3.jpg` : `https://discordapp.com/api/guilds/${guild.id}/icons/${guild.icon}.jpg`}/>
-        <h3><a className={s.name} href={`/server/${guild.id}`}>{guild.name}</a></h3>
-      </li>
+      <div className={s.serveritem}>
+        <div className={s.serverguildicon}>
+          <img src={guild.icon == null ? `https://discordapp.com/api/guilds/97069403178278912/icons/8d7a71e1507514e9ab4345056c8b5cc3.jpg` : `https://discordapp.com/api/guilds/${guild.id}/icons/${guild.icon}.jpg`}/>
+        </div>
+        <div className={s.serverlabel}>
+          <h3><a href={`/server/${guild.id}`}>{guild.name}</a></h3>
+        </div>
+      </div>
     );
   });
 
   return (
     <div className={s.root}>
       <div className={s.container}>
-        <h1 className={s.title}>{user.username}'s Server</h1>
-        <ul className={s.serverList}>{items}</ul>
-        <ul className={s.serverList}>{items}</ul>
+        <h1 className={s.title}>{user.username}'s Servers</h1>
+        {items}
       </div>
     </div>
   );

--- a/src/routes/serverList/Serverlist.js
+++ b/src/routes/serverList/Serverlist.js
@@ -33,12 +33,12 @@ function ServerList({ user }, context) {
 
   const items = user.guilds.map(guild => {
     return (
-      <div className={s.serveritem}>
-        <div className={s.serverguildicon}>
+      <div className={s.serverItem}>
+        <div className={s.serverGuildIcon}>
           <img src={guild.icon == null ? `https://discordapp.com/api/guilds/97069403178278912/icons/8d7a71e1507514e9ab4345056c8b5cc3.jpg` : `https://discordapp.com/api/guilds/${guild.id}/icons/${guild.icon}.jpg`}/>
         </div>
-        <div className={s.serverlabel}>
-          <h3><a href={`/server/${guild.id}`}>{guild.name}</a></h3>
+        <div className={s.serverLabel}>
+          <h3>{guild.name}</h3>
         </div>
       </div>
     );

--- a/src/routes/serverList/index.js
+++ b/src/routes/serverList/index.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import ServerList from './ServerList';
+import ServerList from './Serverlist.js';
 
 export default {
 


### PR DESCRIPTION
The changes to the overall design include:

- A two-column design, as opposed to the single column design that existed before. This ensures it scales nicely on desktop computers.
- Circular guild images, to match the appearance of the guild images in Discord's server view.
- Changed text to h3, and ensured it centers horizontally.
- Fixed a nasty bug where the container div refused to grow height-wise with its contents. This caused the layout to break when there was an odd number of elements.
- Fixed the issue where `npm start` would fail on Linux systems due to an incorrectly cased import.
- Fixed naming of CSS classes from before.

This layout has been tested on Firefox 47.0 on Ubuntu 14.04.4 LTS, as well as the latest stable build of Chrome as of this pull request and was found to work without issue. This layout has NOT been tested on mobile.
