### PR TITLE
Prevented brand text from being covered by navigation on small screens

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -113,6 +113,8 @@
   padding: 5px;
   text-decoration: none;
   font-size: 1.75em; /* ~28px */
+  position: relative;
+  z-index: 2;
 }
 
 .brandTxt {

--- a/src/components/Navigation/Navigation.css
+++ b/src/components/Navigation/Navigation.css
@@ -9,6 +9,8 @@
 
 .root {
   padding: 10px 5px;
+  position: relative;
+  z-index: 1;
 }
 
 .link {


### PR DESCRIPTION
(cell phones)

before:
<img width="50%" alt="before" src="https://user-images.githubusercontent.com/22457086/30995340-90919cae-a487-11e7-94cf-d8af447e1d8c.png">

after:
<img width="50%" alt="after" src="https://user-images.githubusercontent.com/22457086/30995353-96422196-a487-11e7-8594-c026db6e16c2.png">

